### PR TITLE
chore: add GitHub issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in git-rewrite
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  
+  - type: input
+    id: command
+    attributes:
+      label: Command run
+      description: The exact `git-rewrite ...` command you ran.
+      placeholder: "git-rewrite ..."
+    validations:
+      required: true
+  
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen.
+    validations:
+      required: true
+  
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour / error output
+      description: What actually happened. Include any error messages or stack traces.
+      render: shell
+    validations:
+      required: true
+  
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "OS, Python version, git-filter-repo installed (y/n)"
+      placeholder: "macOS 14.0, Python 3.11, git-filter-repo: yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/gfargo/git-rewrite/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for git-rewrite
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the form below.
+  
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: Describe the problem you're trying to solve or the motivation behind this feature.
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+  
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like to see implemented.
+    validations:
+      required: true
+  
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or features you've considered.
+    validations:
+      required: false


### PR DESCRIPTION
Closes #5

This PR adds structured GitHub issue templates to improve issue quality:

## Files added:
- `.github/ISSUE_TEMPLATE/bug_report.yml` - Bug report template with fields for description, command, expected/actual behavior, and environment
- `.github/ISSUE_TEMPLATE/feature_request.yml` - Feature request template with fields for problem/motivation, proposed solution, and alternatives
- `.github/ISSUE_TEMPLATE/config.yml` - Disables blank issues and directs users to Discussions for questions

Both templates render correctly in the GitHub new-issue UI and blank issues are disabled.